### PR TITLE
Changes for Version 1.1

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -94,6 +94,19 @@ async function removeStyle() {
     return;
 }
 
+/**
+ * Open options page on first install
+ * @param {Object} details 
+ */
+function handleInstalled(details) {
+    if (details.reason == 'install') {
+        browser.tabs.create({
+            url: 'options/options.html'
+        });
+    }
+}
+
 let contentScript = null;
 browser.storage.onChanged.addListener(loadSettings);
 loadSettings();
+browser.runtime.onInstalled.addListener(handleInstalled);

--- a/firefox/help/image/check.svg
+++ b/firefox/help/image/check.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="rgba(12, 12, 13, .8)" d="M6 14a1 1 0 0 1-.707-.293l-3-3a1 1 0 0 1 1.414-1.414l2.157 2.157 6.316-9.023a1 1 0 0 1 1.639 1.146l-7 10a1 1 0 0 1-.732.427A.863.863 0 0 1 6 14z"></path></svg>

--- a/firefox/help/script/troubleshoot.js
+++ b/firefox/help/script/troubleshoot.js
@@ -1,0 +1,134 @@
+const UI = {
+    preview: document.getElementById('preview'),
+    button: {
+        color: {
+            yes: document.getElementById('color-yes'),
+            no: document.getElementById('color-no'),
+            fix: document.getElementById('color-fix')
+        },
+        width: {
+            yes: document.getElementById('width-yes'),
+            no: document.getElementById('width-no'),
+            fix: document.getElementById('width-fix')
+        },
+        private: {
+            yes: document.getElementById('private-yes'),
+            no: document.getElementById('private-no')
+        }
+    }
+}
+let currentStage = 1;
+
+function testController(action) {
+    const id = action.target.id.split('-');
+
+    if (id[0] == 'color') {
+        if (id[1] == 'yes') {
+            endStage(1);
+        } else {
+            failStage(1);
+        }
+    } else if (id[0] == 'width') {
+        if (id[1] == 'yes') {
+            endStage(2);
+        } else {
+            failStage(2);
+        }
+    } else {
+        if (id[1] == 'yes') {
+            failStage(3);
+        } else {
+            endStage(3);
+        }
+    }
+}
+
+async function endStage(stage) {
+    let isAllowPrivateBrowsing;
+
+    switch (stage) {
+        case 0:
+            UI.button.color.yes.addEventListener('click', testController);
+            UI.button.color.no.addEventListener('click', testController);
+
+            UI.preview.setAttribute('style', 'scrollbar-width: default !important; scrollbar-color: blue red !important;');
+            break;
+        
+        case 1:
+            document.getElementById('color-test').classList.remove('show');
+            document.getElementById('color-heading').classList.add('success');
+            document.getElementById('width-test').classList.add('show');
+
+            UI.button.color.yes.removeEventListener('click', testController);
+            UI.button.color.no.removeEventListener('click', testController);
+            UI.button.width.yes.addEventListener('click', testController);
+            UI.button.width.no.addEventListener('click', testController);
+
+            UI.preview.setAttribute('style', 'scrollbar-width: none !important; scrollbar-color: unset !important;');
+            break;
+
+        case 2:
+            document.getElementById('width-test').classList.remove('show');
+            document.getElementById('width-heading').classList.add('success');
+            document.getElementById('private-test').classList.add('show');
+            document.getElementById('private-note').classList.add('show');
+
+            UI.button.width.yes.removeEventListener('click', testController);
+            UI.button.width.no.removeEventListener('click', testController);
+
+            isAllowPrivateBrowsing = await browser.extension.isAllowedIncognitoAccess();
+
+            if (isAllowPrivateBrowsing) {
+                endStage(3);
+            } else {
+                UI.button.private.yes.addEventListener('click', testController);
+                UI.button.private.no.addEventListener('click', testController);
+            }
+            break;
+
+        case 3:
+            document.getElementById('private-test').classList.remove('show');
+            document.getElementById('private-note').classList.remove('show');
+            document.getElementById('private-heading').classList.add('success');
+            document.getElementById('finish-test').classList.add('show');
+
+            isAllowPrivateBrowsing = await browser.extension.isAllowedIncognitoAccess();
+
+            if (isAllowPrivateBrowsing) {
+                document.getElementById('private-ignored').style.display = 'none';
+            }
+            break;
+    }
+}
+
+function failStage(stage) {
+    switch (stage) {
+        case 1:
+            document.getElementById('color-test').classList.remove('show');
+            document.getElementById('color-fail').classList.add('show');
+
+            UI.button.color.yes.removeEventListener('click', testController);
+            UI.button.color.no.removeEventListener('click', testController);
+            UI.button.color.fix.addEventListener('click', () => {
+                window.open('https://github.com/WesleyBranton/Custom-Scrollbar/wiki/No-color-customizations', '_blank');
+            });
+            break;
+        
+        case 2:
+            document.getElementById('width-test').classList.remove('show');
+            document.getElementById('width-fail').classList.add('show');
+
+            UI.button.width.yes.removeEventListener('click', testController);
+            UI.button.width.no.removeEventListener('click', testController);
+            UI.button.width.fix.addEventListener('click', () => {
+                window.open('https://github.com/WesleyBranton/Custom-Scrollbar/wiki/No-width-customizations', '_blank');
+            });
+            break;
+
+        case 3:
+            window.open('https://github.com/WesleyBranton/Custom-Scrollbar/wiki/No-customizations-in-Private-Browsing-mode', '_blank');
+            break;
+    }
+}
+
+endStage(0);

--- a/firefox/help/style/troubleshoot.css
+++ b/firefox/help/style/troubleshoot.css
@@ -1,0 +1,39 @@
+body {
+    background: #f9f9fa;
+}
+
+.container {
+    width: 95%;
+    max-width: 1000px;
+    margin: 16px auto;
+    background: white;
+    padding: 16px;
+    box-sizing: border-box;
+    box-shadow: 0 1px 4px var(--grey-90-a10);
+    border-radius: 4px;
+}
+
+#preview {
+    height: 100px;
+    width: 50%;
+    resize: none;
+    background: white;
+    color: black;
+}
+
+.test:not(.show) {
+    display: none !important;
+}
+
+.heading img {
+    flex: unset !important;
+    margin-right: 1em;
+}
+
+.heading:not(.success) img {
+    display: none;
+}
+
+.heading h3 {
+    flex: 1;
+}

--- a/firefox/help/troubleshoot.html
+++ b/firefox/help/troubleshoot.html
@@ -15,9 +15,12 @@
 
 <body class="browser-style">
     <section class="container" id="troubleshoot">
-        <section class="panel-section" id="hello-message">
+        <header class="panel-section panel-section-header">
+            <img class="icon-section-header" src="../icons/icon-32.png">
+            <h1 class="text-section-header">Having issues with Custom Scrollbars?</h1>
+        </header>
+        <section class="panel-section">
             <div>
-                <h1>Having issues with Custom Scrollbars?</h1>
                 <p>Sorry to hear that you are having issues getting Custom Scrollbars to work on your browser. Fortunately, issues can usually be easily fixed.</p>
                 <p>Below is a test page that will test some of the Custom Scrollbars functionality to ensure that your browser has all the necessary settings configured correctly.</p>
                 <p>Take a look at this scrollbar preview and answer the questions below:</p>

--- a/firefox/help/troubleshoot.html
+++ b/firefox/help/troubleshoot.html
@@ -1,0 +1,111 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Having issues with Custom Scrollbars?</title>
+    <link rel="icon" href="../icons/icon-32.png">
+    <link rel="stylesheet" href="../lib/new_browser_style.css">
+    <link rel="stylesheet" href="style/troubleshoot.css">
+</head>
+
+<body class="browser-style">
+    <section class="container" id="troubleshoot">
+        <section class="panel-section" id="hello-message">
+            <div>
+                <h1>Having issues with Custom Scrollbars?</h1>
+                <p>Sorry to hear that you are having issues getting Custom Scrollbars to work on your browser. Fortunately, issues can usually be easily fixed.</p>
+                <p>Below is a test page that will test some of the Custom Scrollbars functionality to ensure that your browser has all the necessary settings configured correctly.</p>
+                <p>Take a look at this scrollbar preview and answer the questions below:</p>
+            </div>
+        </section>
+        <section class="panel-section">
+            <textarea id="preview" readonly disabled>Lorem ipsum dolor sit amet, in porttitor congue taciti velit, ut ipsum integer et proin, a eget, ut dolores, sed nec ante. Aenean ipsum ultricies neque suscipit fusce eu, rutrum mauris, posuere nulla. Arcu nonummy amet nibh et eu leo, risus non, wisi vitae. Mauris erat, nulla a neque arcu etiam, eget metus rhoncus, rhoncus phasellus, ut suspendisse hendrerit imperdiet urna suspendisse. In est ut sollicitudin orci tristique, porta sed cum id nonummy aliquam, ullamcorper pretium. Pellentesque nullam nam quisque sit ultricies, in nec nonummy ante mauris, neque nec montes in, eleifend posuere lacus diam magna scelerisque. Luctus elementum donec leo, lectus integer in justo elit quam. Id amet a. Pellentesque quae a maecenas eget, urna nibh amet eros, placerat ante pellentesque duis suspendisse etiam tempus, nunc proin maecenas interdum quisque cum penatibus, fusce nullam inceptos commodo ut. Arcu lorem purus eu vitae aliquet, dolor nullam nisl varius, vestibulum lacus velit rutrum morbi, nec et.</textarea>
+        </section>
+        <div class="panel-section-separator"></div>
+
+        <!-- Test scrollbar color -->
+        <section class="panel-section heading" id="color-heading">
+            <img src="image/check.svg">
+            <h3>Colors Active</h3>
+        </section>
+        <section class="panel-section test show" id="color-test">
+            <label>Is the scrollbar <span style="color:red">red</span> and <span style="color:blue">blue</span>?</label>
+            <div>
+                <button id="color-yes" class="default">Yes</button>
+                <button id="color-no" class="secondary">No</button>
+            </div>
+        </section>
+        <section class="panel-section test" id="color-fail">
+            <div>
+                <label>Looks like the setting that allows this add-on to adjust the scrollbar color is disabled in your browser.</label>
+                <p class="subtext">Click the "Fix It" button, complete the steps on that page and then restart Firefox.</p>
+            </div>
+            <div>
+                <button id="color-fix" class="default">Fix It</button>
+            </div>
+        </section>
+        <div class="panel-section-separator"></div>
+
+        <!-- Test scrollbar width -->
+        <section class="panel-section heading" id="width-heading">
+            <img src="image/check.svg">
+            <h3>Width Active</h3>
+        </section>
+        <section class="panel-section test" id="width-test">
+            <label>Is the scrollbar now hidden?</label>
+            <div>
+                <button id="width-yes" class="default">Yes</button>
+                <button id="width-no" class="secondary">No</button>
+            </div>
+        </section>
+        <section class="panel-section test" id="width-fail">
+            <div>
+                <label>Looks like the setting that allows this add-on to adjust the scrollbar width is disabled in your browser.</label>
+                <p class="subtext">Click the "Fix It" button, complete the steps on that page and then restart Firefox.</p>
+            </div>
+            <div>
+                <button id="width-fix" class="default">Fix It</button>
+            </div>
+        </section>
+        <div class="panel-section-separator"></div>
+
+        <!-- Test Private Browsing mode -->
+        <section class="panel-section heading" id="private-heading">
+            <img src="image/check.svg">
+            <h3>Private Browsing Access</h3>
+        </section>
+        <section class="panel-section has-help test" id="private-test">
+            <label>You still need to give Custom Scrollbars permission to run in Private Browsing mode</label>
+            <div>
+                <button id="private-yes" class="default">Learn How</button>
+                <button id="private-no" class="secondary">Ignore</button>
+            </div>
+        </section>
+        <section class="panel-section help-row has-help test" id="private-note">
+            <div class="message-bar warning">Scrollbars will not be customized on Private Browsing windows if permission is not granted</div>
+        </section>
+        <div class="panel-section-separator"></div>
+
+        <!-- Test is finished -->
+        <section class="panel-section heading" id="finish-heading">
+            <img src="image/check.svg">
+            <h3>Finish</h3>
+        </section>
+        <section class="panel-section has-help test" id="finish-test">
+            <div>
+                <p>You have completed the troubleshooter. If you made it this far, it means there are no issues with your browser settings and the Custom Scrollbars add-on should be working normally.</p>
+                <p id="private-ignored">Please note that you still have not yet granted this add-on permission to run in Private Browsing windows, so the scrollbars will not be customized when running in that mode.</p>
+                <p>If you are still having issues with only some specific websites (not all), then you may be viewing a website that the Custom Scrollbars add-on cannot customize. <a href="https://github.com/WesleyBranton/Custom-Scrollbar/wiki/Pages-this-extension-cannot-modify" target="_blank">Click here to learn more.</a></p>
+                <p>If you are still having issues with all websites, try restarting your browser.</p>
+            </div>
+        </section>
+    </section>
+    <script src="script/troubleshoot.js"></script>
+</body>
+
+</html>

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -19,7 +19,7 @@
     },
 
     "options_ui": {
-        "page": "options/options.html",
+        "page": "options/preview.html",
         "browser_style": false
     },
 

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -14,6 +14,14 @@
 <body class="browser-style">
     <form name="settings">
         <section class="panel-section">
+            <div class="message-bar private hide" id="private-notice">
+                <div>Custom scrollbars will not be visible in Private Browsing windows unless you give this extension
+                    permission to run in Private Browsing mode.
+                    <a href="https://github.com/WesleyBranton/Custom-Scrollbar/wiki/No-customizations-in-Private-Browsing-mode" target="_blank">Learn more...</a>
+                </div>
+            </div>
+        </section>
+        <section class="panel-section help-row">
             <label for="width">Scrollbar width</label>
             <div>
                 <label><input type="radio" name="width" value="unset"> Default</label><br>

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -71,8 +71,13 @@
                 <div class="message-bar warning">You have unsaved changes!</div>
             </div>
         </section>
-        <section class="panel-section help-row">
+        <section class="panel-section help-row has-help">
             <div class="message-bar general">You will need to refresh all tabs to see the changes</div>
+        </section>
+        <section class="panel-section help-row">
+            <div class="message-bar general">
+                <div>Something not working? <a href="../help/troubleshoot.html" target="_blank">Click here...</a></div>
+            </div>
         </section>
     </form>
     <script src="../lib/vanilla-picker.min.js"></script>

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -7,12 +7,18 @@
 
 <head>
     <meta charset="utf-8" />
+    <title>Custom Scrollbars Options</title>
+    <link rel="icon" href="../icons/icon-32.png">
     <link rel="stylesheet" href="../lib/new_browser_style.css" />
     <link rel="stylesheet" href="style.css" />
 </head>
 
 <body class="browser-style">
     <form name="settings">
+        <header class="panel-section panel-section-header">
+            <img class="icon-section-header" src="../icons/icon-32.png">
+            <h1 class="text-section-header">Custom Scrollbars Options</h1>
+          </header>
         <section class="panel-section">
             <div class="message-bar private hide" id="private-notice">
                 <div>Custom scrollbars will not be visible in Private Browsing windows unless you give this extension

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -44,13 +44,19 @@
         </section>
         <div class="panel-section-separator only-colors"></div>
         <section class="panel-section only-colors">
-            <label for="colorThumb">Scrollbar thumb color</label>
+            <div class="image-helper">
+                <img src="thumb.svg">
+                <label for="colorThumb">Scrollbar thumb color</label>
+            </div>
             <div id="colorThumb">
             </div>
         </section>
         <div class="panel-section-separator only-colors"></div>
         <section class="panel-section only-colors">
-            <label for="colorTrack">Scrollbar track color</label>
+            <div class="image-helper">
+                <img src="track.svg">
+                <label for="colorTrack">Scrollbar track color</label>
+            </div>
             <div id="colorTrack">
             </div>
         </section>

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -22,6 +22,11 @@
             </div>
         </section>
         <section class="panel-section help-row">
+            <label>Live Preview</label>
+            <textarea id="preview" readonly disabled>Lorem ipsum dolor sit amet, in porttitor congue taciti velit, ut ipsum integer et proin, a eget, ut dolores, sed nec ante. Aenean ipsum ultricies neque suscipit fusce eu, rutrum mauris, posuere nulla. Arcu nonummy amet nibh et eu leo, risus non, wisi vitae. Mauris erat, nulla a neque arcu etiam, eget metus rhoncus, rhoncus phasellus, ut suspendisse hendrerit imperdiet urna suspendisse. In est ut sollicitudin orci tristique, porta sed cum id nonummy aliquam, ullamcorper pretium. Pellentesque nullam nam quisque sit ultricies, in nec nonummy ante mauris, neque nec montes in, eleifend posuere lacus diam magna scelerisque. Luctus elementum donec leo, lectus integer in justo elit quam. Id amet a. Pellentesque quae a maecenas eget, urna nibh amet eros, placerat ante pellentesque duis suspendisse etiam tempus, nunc proin maecenas interdum quisque cum penatibus, fusce nullam inceptos commodo ut. Arcu lorem purus eu vitae aliquet, dolor nullam nisl varius, vestibulum lacus velit rutrum morbi, nec et.</textarea>
+        </section>
+        <div class="panel-section-separator"></div>
+        <section class="panel-section">
             <label for="width">Scrollbar width</label>
             <div>
                 <label><input type="radio" name="width" value="unset"> Default</label><br>

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -18,7 +18,7 @@
         <header class="panel-section panel-section-header">
             <img class="icon-section-header" src="../icons/icon-32.png">
             <h1 class="text-section-header">Custom Scrollbars Options</h1>
-          </header>
+        </header>
         <section class="panel-section">
             <div class="message-bar private hide" id="private-notice">
                 <div>Custom scrollbars will not be visible in Private Browsing windows unless you give this extension

--- a/firefox/options/preview.html
+++ b/firefox/options/preview.html
@@ -1,0 +1,25 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+   <!DOCTYPE html>
+   <html>
+   
+   <head>
+       <meta charset="utf-8">
+       <link rel="stylesheet" href="../lib/new_browser_style.css">
+   </head>
+   
+   <body class="browser-style">
+           <section class="panel-section">
+                <label>Click the button to open the options page</label>
+                <div>
+                    <button id="openOptions" class="default">Open Options</button>
+                </div>
+           </section>
+       <script src="../lib/vanilla-picker.min.js"></script>
+       <script src="preview.js"></script>
+   </body>
+   
+   </html>
+   

--- a/firefox/options/preview.js
+++ b/firefox/options/preview.js
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+document.getElementById('openOptions').addEventListener('click', () => {
+    window.open('options.html', '_blank');
+});

--- a/firefox/options/script.js
+++ b/firefox/options/script.js
@@ -27,6 +27,7 @@ function restore(setting) {
 
     togglePrivateNotice();
     toggleChangesWarning(false);
+    updateWindowScrollbar();
 }
 
 /**
@@ -46,7 +47,9 @@ function save() {
         colorTrack: colTrack,
         colorThumb: colThumb
     });
+
     toggleChangesWarning(false);
+    updateWindowScrollbar();
 }
 
 /**
@@ -126,12 +129,31 @@ async function togglePrivateNotice() {
  */
 function updatePreview() {
     const preview = document.getElementById('preview');
+    const css = getNewCSS();
+    
+    preview.setAttribute('style', css);
+}
+
+/**
+ * Changes scrollbars on options page to match the new settings
+ */
+function updateWindowScrollbar() {
+    const css = getNewCSS();
+    document.documentElement.setAttribute('style', css);
+}
+
+/**
+ * Generates new CSS code for scrollbars
+ * @returns {string} css
+ */
+function getNewCSS() {
     const width = document.settings.width.value;
     let colThumb = (document.settings.customColors.value == 'yes') ? colorPickerThumb.color.hex : 'unset';
     let colTrack = (document.settings.customColors.value == 'yes') ? colorPickerTrack.color.hex : 'unset';
 
     const css = `scrollbar-width: ${width} !important; scrollbar-color: ${colThumb} ${colTrack} !important;`;
-    preview.setAttribute('style', css);
+
+    return css;
 }
 
 let colorPickerThumb, colorPickerTrack, previousToggleValue;

--- a/firefox/options/script.js
+++ b/firefox/options/script.js
@@ -25,6 +25,7 @@ function restore(setting) {
     colorPickerThumb.setColor(setting.colorThumb);
     colorPickerTrack.setColor(setting.colorTrack);
 
+    togglePrivateNotice();
     toggleChangesWarning(false);
 }
 
@@ -99,6 +100,18 @@ function toggleChangesWarning(show) {
         document.getElementById('saveWarning').className = 'unsaved';
     } else {
         document.getElementById('saveWarning').className = 'saved';
+    }
+}
+
+/**
+ * Display Private Browsing access warning message, if required
+ * @async
+ */
+async function togglePrivateNotice() {
+    let isAllowPrivateBrowsing = await browser.extension.isAllowedIncognitoAccess();
+
+    if (!isAllowPrivateBrowsing) {
+        document.getElementById('private-notice').classList.remove('hide');
     }
 }
 

--- a/firefox/options/script.js
+++ b/firefox/options/script.js
@@ -98,8 +98,10 @@ function toggleColors() {
 function toggleChangesWarning(show) {
     if (show) {
         document.getElementById('saveWarning').className = 'unsaved';
+        document.getElementById('saveChanges').disabled = false;
     } else {
         document.getElementById('saveWarning').className = 'saved';
+        document.getElementById('saveChanges').disabled = true;
     }
 
     updatePreview();

--- a/firefox/options/script.js
+++ b/firefox/options/script.js
@@ -101,6 +101,8 @@ function toggleChangesWarning(show) {
     } else {
         document.getElementById('saveWarning').className = 'saved';
     }
+
+    updatePreview();
 }
 
 /**
@@ -113,6 +115,19 @@ async function togglePrivateNotice() {
     if (!isAllowPrivateBrowsing) {
         document.getElementById('private-notice').classList.remove('hide');
     }
+}
+
+/**
+ * Updates the live preview textarea style
+ */
+function updatePreview() {
+    const preview = document.getElementById('preview');
+    const width = document.settings.width.value;
+    let colThumb = (document.settings.customColors.value == 'yes') ? colorPickerThumb.color.hex : 'unset';
+    let colTrack = (document.settings.customColors.value == 'yes') ? colorPickerTrack.color.hex : 'unset';
+
+    const css = `scrollbar-width: ${width} !important; scrollbar-color: ${colThumb} ${colTrack} !important;`;
+    preview.setAttribute('style', css);
 }
 
 let colorPickerThumb, colorPickerTrack, previousToggleValue;

--- a/firefox/options/script.js
+++ b/firefox/options/script.js
@@ -99,9 +99,11 @@ function toggleChangesWarning(show) {
     if (show) {
         document.getElementById('saveWarning').className = 'unsaved';
         document.getElementById('saveChanges').disabled = false;
+        pendingChanges = true;
     } else {
         document.getElementById('saveWarning').className = 'saved';
         document.getElementById('saveChanges').disabled = true;
+        pendingChanges = false;
     }
 
     updatePreview();
@@ -133,9 +135,17 @@ function updatePreview() {
 }
 
 let colorPickerThumb, colorPickerTrack, previousToggleValue;
+let pendingChanges = false;
 createColorPickers();
 let data = browser.storage.local.get();
 data.then(restore);
 
 document.getElementById('saveChanges').addEventListener('click', save);
 document.settings.addEventListener('change', toggleColors);
+window.addEventListener('beforeunload', (event) => {
+    // Prevent user from leaving if they have unsaved changes
+    if (pendingChanges) {
+        event.preventDefault();
+        event.returnValue = '';
+    }
+});

--- a/firefox/options/style.css
+++ b/firefox/options/style.css
@@ -2,6 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+body {
+    background: #f9f9fa;
+}
+
+form {
+    width: 95%;
+    max-width: 1000px;
+    margin: 16px auto;
+    background: white;
+    padding: 16px;
+    box-sizing: border-box;
+    box-shadow: 0 1px 4px var(--grey-90-a10);
+    border-radius: 4px;
+}
+
 .no-custom-colors .only-colors {
     display: none !important;
 }

--- a/firefox/options/style.css
+++ b/firefox/options/style.css
@@ -59,3 +59,18 @@
     background: white;
     color: black;
 }
+
+.image-helper {
+    display: flex;
+    align-items: center;
+}
+
+.image-helper label {
+    flex: 1;
+}
+
+.image-helper img {
+    width: 5%;
+    flex: unset !important;
+    margin-right: 1em;
+}

--- a/firefox/options/style.css
+++ b/firefox/options/style.css
@@ -85,7 +85,7 @@ form {
 }
 
 .image-helper img {
-    width: 5%;
+    width: 20px;
     flex: unset !important;
     margin-right: 1em;
 }

--- a/firefox/options/style.css
+++ b/firefox/options/style.css
@@ -51,3 +51,11 @@
 .hide {
     display: none !important;
 }
+
+#preview {
+    height: 100px;
+    width: 50%;
+    resize: none;
+    background: white;
+    color: black;
+}

--- a/firefox/options/style.css
+++ b/firefox/options/style.css
@@ -31,3 +31,23 @@
 #saveWarning.unsaved .success {
     display: none !important;
 }
+
+.message-bar.private {
+    background-color: #8D20AE;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="rgba(249, 249, 250, .8)" d="M12.408 11.992c-1.663 0-2.813-2-4.408-2s-2.844 2-4.408 2C1.54 11.992.025 10.048 0 6.719c-.015-2.068.6-2.727 3.265-2.727S6.709 5.082 8 5.082s2.071-1.091 4.735-1.091 3.28.66 3.265 2.727c-.025 3.33-1.54 5.274-3.592 5.274zM4.572 6.537c-1.619.07-2.286 1.035-2.286 1.273s1.073.909 2.122.909 2.286-.384 2.286-.727a1.9 1.9 0 0 0-2.122-1.455zm6.857 0a1.9 1.9 0 0 0-2.123 1.455c0 .343 1.236.727 2.286.727s2.122-.671 2.122-.909-.667-1.203-2.286-1.273z"></path></svg>');
+    padding-top: 6px;
+    padding-bottom: 6px;
+}
+
+.message-bar.private * {
+    color: white;
+}
+
+.message-bar.private a {
+    font-weight: bold;
+    text-decoration: underline;
+}
+
+.hide {
+    display: none !important;
+}

--- a/firefox/options/thumb.svg
+++ b/firefox/options/thumb.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.2" width="20mm" height="100mm" viewBox="0 0 2000 10000" preserveAspectRatio="xMidYMid" fill-rule="evenodd" stroke-width="28.222" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" xmlns:ooo="http://xml.openoffice.org/svg/export" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:presentation="http://sun.com/xmlns/staroffice/presentation" xmlns:smil="http://www.w3.org/2001/SMIL20/" xmlns:anim="urn:oasis:names:tc:opendocument:xmlns:animation:1.0" xml:space="preserve">
+ <defs class="ClipPathGroup">
+  <clipPath id="presentation_clip_path" clipPathUnits="userSpaceOnUse">
+   <rect x="0" y="0" width="2000" height="10000"/>
+  </clipPath>
+  <clipPath id="presentation_clip_path_shrink" clipPathUnits="userSpaceOnUse">
+   <rect x="2" y="10" width="1996" height="9980"/>
+  </clipPath>
+ </defs>
+ <defs class="TextShapeIndex">
+  <g ooo:slide="id1" ooo:id-list="id3 id4 id5 id6"/>
+ </defs>
+ <defs class="EmbeddedBulletChars">
+  <g id="bullet-char-template-57356" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 580,1141 L 1163,571 580,0 -4,571 580,1141 Z"/>
+  </g>
+  <g id="bullet-char-template-57354" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 8,1128 L 1137,1128 1137,0 8,0 8,1128 Z"/>
+  </g>
+  <g id="bullet-char-template-10146" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 174,0 L 602,739 174,1481 1456,739 174,0 Z M 1358,739 L 309,1346 659,739 1358,739 Z"/>
+  </g>
+  <g id="bullet-char-template-10132" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 2015,739 L 1276,0 717,0 1260,543 174,543 174,936 1260,936 717,1481 1274,1481 2015,739 Z"/>
+  </g>
+  <g id="bullet-char-template-10007" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 0,-2 C -7,14 -16,27 -25,37 L 356,567 C 262,823 215,952 215,954 215,979 228,992 255,992 264,992 276,990 289,987 310,991 331,999 354,1012 L 381,999 492,748 772,1049 836,1024 860,1049 C 881,1039 901,1025 922,1006 886,937 835,863 770,784 769,783 710,716 594,584 L 774,223 C 774,196 753,168 711,139 L 727,119 C 717,90 699,76 672,76 641,76 570,178 457,381 L 164,-76 C 142,-110 111,-127 72,-127 30,-127 9,-110 8,-76 1,-67 -2,-52 -2,-32 -2,-23 -1,-13 0,-2 Z"/>
+  </g>
+  <g id="bullet-char-template-10004" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 285,-33 C 182,-33 111,30 74,156 52,228 41,333 41,471 41,549 55,616 82,672 116,743 169,778 240,778 293,778 328,747 346,684 L 369,508 C 377,444 397,411 428,410 L 1163,1116 C 1174,1127 1196,1133 1229,1133 1271,1133 1292,1118 1292,1087 L 1292,965 C 1292,929 1282,901 1262,881 L 442,47 C 390,-6 338,-33 285,-33 Z"/>
+  </g>
+  <g id="bullet-char-template-9679" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 813,0 C 632,0 489,54 383,161 276,268 223,411 223,592 223,773 276,916 383,1023 489,1130 632,1184 813,1184 992,1184 1136,1130 1245,1023 1353,916 1407,772 1407,592 1407,412 1353,268 1245,161 1136,54 992,0 813,0 Z"/>
+  </g>
+  <g id="bullet-char-template-8226" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 346,457 C 273,457 209,483 155,535 101,586 74,649 74,723 74,796 101,859 155,911 209,963 273,989 346,989 419,989 480,963 531,910 582,859 608,796 608,723 608,648 583,586 532,535 482,483 420,457 346,457 Z"/>
+  </g>
+  <g id="bullet-char-template-8211" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M -4,459 L 1135,459 1135,606 -4,606 -4,459 Z"/>
+  </g>
+  <g id="bullet-char-template-61548" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 173,740 C 173,903 231,1043 346,1159 462,1274 601,1332 765,1332 928,1332 1067,1274 1183,1159 1299,1043 1357,903 1357,740 1357,577 1299,437 1183,322 1067,206 928,148 765,148 601,148 462,206 346,322 231,437 173,577 173,740 Z"/>
+  </g>
+ </defs>
+ <g>
+  <g id="id2" class="Master_Slide">
+   <g id="bg-id2" class="Background"/>
+   <g id="bo-id2" class="BackgroundObjects"/>
+  </g>
+ </g>
+ <g class="SlideGroup">
+  <g>
+   <g id="container-id1">
+    <g id="id1" class="Slide" clip-path="url(#presentation_clip_path)">
+     <g class="Page">
+      <g class="Group">
+       <g class="com.sun.star.drawing.CustomShape">
+        <g id="id3">
+         <rect class="BoundingBox" stroke="none" fill="none" x="0" y="0" width="2001" height="10001"/>
+         <path fill="rgb(237,237,240)" stroke="none" d="M 1000,10000 L 0,10000 0,0 2000,0 2000,10000 1000,10000 Z"/>
+        </g>
+       </g>
+       <g class="com.sun.star.drawing.CustomShape">
+        <g id="id4">
+         <rect class="BoundingBox" stroke="none" fill="none" x="54" y="3540" width="1893" height="4781"/>
+         <path fill="rgb(0,96,223)" stroke="none" d="M 1000,8320 L 54,8320 54,3540 1946,3540 1946,8320 1000,8320 Z"/>
+        </g>
+       </g>
+       <g class="Group">
+        <g class="Graphic">
+         <g id="id5">
+          <rect class="BoundingBox" stroke="none" fill="none" x="300" y="90" width="1402" height="1621"/>
+          <path fill="rgb(12,12,13)" fill-opacity="0.8" stroke="rgb(255,255,255)" stroke-opacity="0.8" d="M 1371,1173 C 1365,1169 1359,1164 1354,1158 L 1001,749 647,1158 C 642,1163 636,1168 631,1172 618,1180 604,1185 589,1185 575,1185 561,1180 548,1172 536,1164 525,1152 518,1137 511,1123 507,1106 507,1089 507,1073 511,1056 518,1042 521,1035 526,1029 530,1023 L 942,547 C 947,541 953,536 959,532 972,523 986,519 1000,519 1015,519 1029,523 1042,532 1048,536 1054,541 1059,547 L 1471,1023 C 1476,1029 1480,1036 1484,1043 1491,1057 1495,1074 1495,1091 1495,1107 1491,1124 1484,1138 1477,1153 1466,1165 1454,1173 1441,1181 1427,1186 1413,1186 1398,1186 1384,1181 1371,1173 Z"/>
+         </g>
+        </g>
+        <g class="Graphic">
+         <g id="id6">
+          <rect class="BoundingBox" stroke="none" fill="none" x="299" y="8290" width="1403" height="1621"/>
+          <path fill="rgb(12,12,13)" fill-opacity="0.8" stroke="rgb(255,255,255)" stroke-opacity="0.8" d="M 1371,8827 C 1365,8831 1359,8836 1354,8842 L 1000,9251 647,8842 C 642,8837 636,8832 631,8828 618,8820 604,8815 589,8815 575,8815 561,8820 548,8828 536,8836 525,8848 518,8863 511,8877 507,8894 507,8911 507,8927 511,8944 518,8958 521,8965 526,8971 530,8977 L 942,9453 C 947,9459 953,9464 959,9468 972,9477 986,9481 1000,9481 1015,9481 1029,9477 1042,9468 1048,9464 1054,9459 1059,9453 L 1471,8977 C 1476,8971 1480,8964 1484,8957 1491,8943 1495,8926 1495,8909 1495,8893 1491,8876 1484,8862 1477,8847 1466,8835 1454,8827 1441,8819 1427,8814 1413,8814 1398,8814 1384,8819 1371,8827 Z"/>
+         </g>
+        </g>
+       </g>
+      </g>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/firefox/options/track.svg
+++ b/firefox/options/track.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.2" width="20mm" height="100mm" viewBox="0 0 2000 10000" preserveAspectRatio="xMidYMid" fill-rule="evenodd" stroke-width="28.222" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" xmlns:ooo="http://xml.openoffice.org/svg/export" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:presentation="http://sun.com/xmlns/staroffice/presentation" xmlns:smil="http://www.w3.org/2001/SMIL20/" xmlns:anim="urn:oasis:names:tc:opendocument:xmlns:animation:1.0" xml:space="preserve">
+ <defs class="ClipPathGroup">
+  <clipPath id="presentation_clip_path" clipPathUnits="userSpaceOnUse">
+   <rect x="0" y="0" width="2000" height="10000"/>
+  </clipPath>
+  <clipPath id="presentation_clip_path_shrink" clipPathUnits="userSpaceOnUse">
+   <rect x="2" y="10" width="1996" height="9980"/>
+  </clipPath>
+ </defs>
+ <defs class="TextShapeIndex">
+  <g ooo:slide="id1" ooo:id-list="id3 id4 id5 id6"/>
+ </defs>
+ <defs class="EmbeddedBulletChars">
+  <g id="bullet-char-template-57356" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 580,1141 L 1163,571 580,0 -4,571 580,1141 Z"/>
+  </g>
+  <g id="bullet-char-template-57354" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 8,1128 L 1137,1128 1137,0 8,0 8,1128 Z"/>
+  </g>
+  <g id="bullet-char-template-10146" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 174,0 L 602,739 174,1481 1456,739 174,0 Z M 1358,739 L 309,1346 659,739 1358,739 Z"/>
+  </g>
+  <g id="bullet-char-template-10132" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 2015,739 L 1276,0 717,0 1260,543 174,543 174,936 1260,936 717,1481 1274,1481 2015,739 Z"/>
+  </g>
+  <g id="bullet-char-template-10007" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 0,-2 C -7,14 -16,27 -25,37 L 356,567 C 262,823 215,952 215,954 215,979 228,992 255,992 264,992 276,990 289,987 310,991 331,999 354,1012 L 381,999 492,748 772,1049 836,1024 860,1049 C 881,1039 901,1025 922,1006 886,937 835,863 770,784 769,783 710,716 594,584 L 774,223 C 774,196 753,168 711,139 L 727,119 C 717,90 699,76 672,76 641,76 570,178 457,381 L 164,-76 C 142,-110 111,-127 72,-127 30,-127 9,-110 8,-76 1,-67 -2,-52 -2,-32 -2,-23 -1,-13 0,-2 Z"/>
+  </g>
+  <g id="bullet-char-template-10004" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 285,-33 C 182,-33 111,30 74,156 52,228 41,333 41,471 41,549 55,616 82,672 116,743 169,778 240,778 293,778 328,747 346,684 L 369,508 C 377,444 397,411 428,410 L 1163,1116 C 1174,1127 1196,1133 1229,1133 1271,1133 1292,1118 1292,1087 L 1292,965 C 1292,929 1282,901 1262,881 L 442,47 C 390,-6 338,-33 285,-33 Z"/>
+  </g>
+  <g id="bullet-char-template-9679" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 813,0 C 632,0 489,54 383,161 276,268 223,411 223,592 223,773 276,916 383,1023 489,1130 632,1184 813,1184 992,1184 1136,1130 1245,1023 1353,916 1407,772 1407,592 1407,412 1353,268 1245,161 1136,54 992,0 813,0 Z"/>
+  </g>
+  <g id="bullet-char-template-8226" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 346,457 C 273,457 209,483 155,535 101,586 74,649 74,723 74,796 101,859 155,911 209,963 273,989 346,989 419,989 480,963 531,910 582,859 608,796 608,723 608,648 583,586 532,535 482,483 420,457 346,457 Z"/>
+  </g>
+  <g id="bullet-char-template-8211" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M -4,459 L 1135,459 1135,606 -4,606 -4,459 Z"/>
+  </g>
+  <g id="bullet-char-template-61548" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 173,740 C 173,903 231,1043 346,1159 462,1274 601,1332 765,1332 928,1332 1067,1274 1183,1159 1299,1043 1357,903 1357,740 1357,577 1299,437 1183,322 1067,206 928,148 765,148 601,148 462,206 346,322 231,437 173,577 173,740 Z"/>
+  </g>
+ </defs>
+ <g>
+  <g id="id2" class="Master_Slide">
+   <g id="bg-id2" class="Background"/>
+   <g id="bo-id2" class="BackgroundObjects"/>
+  </g>
+ </g>
+ <g class="SlideGroup">
+  <g>
+   <g id="container-id1">
+    <g id="id1" class="Slide" clip-path="url(#presentation_clip_path)">
+     <g class="Page">
+      <g class="Group">
+       <g class="com.sun.star.drawing.CustomShape">
+        <g id="id3">
+         <rect class="BoundingBox" stroke="none" fill="none" x="0" y="0" width="2001" height="10001"/>
+         <path fill="rgb(0,96,223)" stroke="none" d="M 1000,10000 L 0,10000 0,0 2000,0 2000,10000 1000,10000 Z"/>
+        </g>
+       </g>
+       <g class="com.sun.star.drawing.CustomShape">
+        <g id="id4">
+         <rect class="BoundingBox" stroke="none" fill="none" x="54" y="3540" width="1893" height="4781"/>
+         <path fill="rgb(237,237,240)" stroke="none" d="M 1000,8320 L 54,8320 54,3540 1946,3540 1946,8320 1000,8320 Z"/>
+        </g>
+       </g>
+       <g class="Group">
+        <g class="Graphic">
+         <g id="id5">
+          <rect class="BoundingBox" stroke="none" fill="none" x="300" y="90" width="1402" height="1621"/>
+          <path fill="rgb(12,12,13)" fill-opacity="0.8" stroke="rgb(255,255,255)" stroke-opacity="0.8" d="M 1371,1173 C 1365,1169 1359,1164 1354,1158 L 1001,749 647,1158 C 642,1163 636,1168 631,1172 618,1180 604,1185 589,1185 575,1185 561,1180 548,1172 536,1164 525,1152 518,1137 511,1123 507,1106 507,1089 507,1073 511,1056 518,1042 521,1035 526,1029 530,1023 L 942,547 C 947,541 953,536 959,532 972,523 986,519 1000,519 1015,519 1029,523 1042,532 1048,536 1054,541 1059,547 L 1471,1023 C 1476,1029 1480,1036 1484,1043 1491,1057 1495,1074 1495,1091 1495,1107 1491,1124 1484,1138 1477,1153 1466,1165 1454,1173 1441,1181 1427,1186 1413,1186 1398,1186 1384,1181 1371,1173 Z"/>
+         </g>
+        </g>
+        <g class="Graphic">
+         <g id="id6">
+          <rect class="BoundingBox" stroke="none" fill="none" x="299" y="8290" width="1403" height="1621"/>
+          <path fill="rgb(12,12,13)" fill-opacity="0.8" stroke="rgb(255,255,255)" stroke-opacity="0.8" d="M 1371,8827 C 1365,8831 1359,8836 1354,8842 L 1000,9251 647,8842 C 642,8837 636,8832 631,8828 618,8820 604,8815 589,8815 575,8815 561,8820 548,8828 536,8836 525,8848 518,8863 511,8877 507,8894 507,8911 507,8927 511,8944 518,8958 521,8965 526,8971 530,8977 L 942,9453 C 947,9459 953,9464 959,9468 972,9477 986,9481 1000,9481 1015,9481 1029,9477 1042,9468 1048,9464 1054,9459 1059,9453 L 1471,8977 C 1476,8971 1480,8964 1484,8957 1491,8943 1495,8926 1495,8909 1495,8893 1491,8876 1484,8862 1477,8847 1466,8835 1454,8827 1441,8819 1427,8814 1413,8814 1398,8814 1384,8819 1371,8827 Z"/>
+         </g>
+        </g>
+       </g>
+      </g>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>


### PR DESCRIPTION
**[NEW]** Preview window added to options page (issue #4)
**[NEW]** Troubleshooting utility added to help users detect browser settings issues
**[NEW]** Warning displays on options page if add-on doesn't have permission for Private Browsing (issue #6)
**[NEW]** Images added to the options page help identify the difference between thumb and track (issue #7)
**[NEW]** Add-on options page is automatically opened when the add-on is installed (issue #5)
**[NEW]** User is prompted when attempting to close options page with unsaved changes
**[CHANGE]** Options now open new tab
**[CHANGE]** Save button is disabled when there are no changes to save