### PR TITLE
Removed color and width tests from troubleshooting page on Firefox 79

### DIFF
--- a/firefox/help/script/troubleshoot.js
+++ b/firefox/help/script/troubleshoot.js
@@ -147,4 +147,19 @@ function failStage(stage) {
     }
 }
 
+/**
+ * Automatically bypasses the color and width tests for Firefox 79+
+ * @async
+ */
+async function handleVersion79() {
+    const browserInfo = await browser.runtime.getBrowserInfo();
+    const browserVersion = parseInt(browserInfo.version.split('.', 1)[0]);
+
+    if (browserVersion >= 79) {
+        endStage(1);
+        endStage(2);
+    }
+}
+
 endStage(0);
+handleVersion79();


### PR DESCRIPTION
This pull requests will automatically pass the color and width tests for versions of Firefox 79+ because that advanced option no longer exists in those versions and can no longer cause this issue. Closes #17.