### PR TITLE
Stop add-on from overriding default Firefox scrollbar colors

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -22,11 +22,20 @@ const webBase = 'https://addons.wesleybranton.com/addon/custom-scrollbars';
  * @returns Data with defaults 
  */
 function loadWithDefaults(settings) {
+    const includeColors = settings.colorThumb && settings.colorTrack;
+
     const keys = Object.keys(defaults);
     for (const key of keys) {
         if (typeof defaults[key] != typeof settings[key]) {
             settings[key] = defaults[key];
         }
     }
+
+    // Don't override colors
+    if (!includeColors) {
+        settings['colorThumb'] = null;
+        settings['colorTrack'] = null;
+    }
+
     return settings;
 }

--- a/src/options/scripts/options.js
+++ b/src/options/scripts/options.js
@@ -77,8 +77,8 @@ function loadScrollbar(id) {
         previousToggleValue = document.settings.customColors.value;
         toggleColorSettings();
 
-        colorPickerThumb.color.hex8String = scrollbar.colorThumb;
-        colorPickerTrack.color.hex8String = scrollbar.colorTrack;
+        colorPickerThumb.color.hex8String = (scrollbar.colorThumb) ? scrollbar.colorThumb : defaults.colorThumb;
+        colorPickerTrack.color.hex8String = (scrollbar.colorTrack) ? scrollbar.colorTrack : defaults.colorTrack;
 
         toggleCustomWidth();
         toggleHiddenSettings();


### PR DESCRIPTION
I've changed the CSS generation code to make it easier to maintain and easier to read.
Closes #130.